### PR TITLE
Update package.json to prepare for an npm package release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,23 @@
 {
+  "name": "@nihruk/cds",
+  "description": "NIHR Common Design System",
+  "author": "National Institute for Health and Care Research",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nihruk/cds.git"
+  },
+  "keywords": [
+    "nihr",
+    "common",
+    "design",
+    "system"
+  ],
+  "bugs": {
+    "url": "https://github.com/nihruk/cds/issues"
+  },
+  "homepage": "https://github.com/nihruk/cds#readme",
   "dependencies": {
     "bootstrap": "^5.2.2"
   }


### PR DESCRIPTION
This expands `package.json` with all the fields required to allow the CDS to be published as an npm package.