### PR TITLE
Lint all CSS and JS code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "eslint:recommended"
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Test
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: 'Node.js 16'
+            nodejs: '16'
+          - name: 'Node.js 18'
+            nodejs: '18'
+
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.nodejs }}
+
+      - name: Get the npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: npm-${{ hashFiles('./package.json') }}
+          restore-keys: |
+            npm-
+
+      - name: Install npm dependencies
+        run: |
+          npm install
+        shell: bash
+
+      - name: Run the tests
+        run: |
+          npm run test
+        shell: bash

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 ## NIHR Common Design System (CDS)
 
-These are the assets supporting the NIHR [Common Design System](https://nihr.atlassian.net/wiki/spaces/CDS).
+This is a library that implements the NIHR [Common Design System](https://nihr.atlassian.net/wiki/spaces/CDS) on top of 
+[Bootstrap](https://getbootstrap.com/).
+
+### Usage
+
+#### Requirements
+- [Node.js](https://nodejs.org/) 16 or newer
+- npm or a compatible package manager
+
+#### Installation
+Run `npm install @nihruk/cds` in your existing project.
+
+### Development
+
+#### Installation
+Clone this repository, navigate into its root directory, and run `npm install`.
+
+#### Testing
+Run `npm run test`.
+
+#### Fixing problems automatically
+Run `npm run fix`.
 
 ## Copyright
 Copyright (C) 2017 Crown Copyright (National Institute for Health and Care Research)

--- a/package.json
+++ b/package.json
@@ -20,5 +20,19 @@
   "homepage": "https://github.com/nihruk/cds#readme",
   "dependencies": {
     "bootstrap": "^5.2.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.25.0",
+    "stylelint": "^14.13.0",
+    "stylelint-config-standard": "^28.0.0"
+  },
+  "scripts": {
+    "test-lint-css": "./node_modules/.bin/stylelint --allow-empty-input \"**/*.css\"",
+    "test-lint-js": "./node_modules/.bin/eslint --no-error-on-unmatched-pattern .",
+    "test-lint": "npm run test-lint-css && npm run test-lint-js",
+    "test": "npm run test-lint",
+    "fix-css": "./node_modules/.bin/stylelint --fix --allow-empty-input \"**/*.css\"",
+    "fix-js": "./node_modules/.bin/eslint --fix --no-error-on-unmatched-pattern .",
+    "fix": "npm run fix-css && npm run fix-js"
   }
 }


### PR DESCRIPTION
This adds initial test automation in the form of CSS and JS linting, enforcing a code style as well as scanning for potential bugs and vulnerabilities. If we have any immediate preferences for which coding standards to enforce, we can update this PR before we merge it. Otherwise we can easily do so later, because both linters can automatically make our code comply with any configured coding standard, which I hooked up together under `npm run fix`.