### PR TITLE
Allow new versions to be released through Github

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -1,0 +1,50 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number (Semantic Versioning 2: https://semver.org/)'
+        required: true
+        type: string
+      commit:
+        description: 'Hash of the commit to release'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commit }}
+
+      - name: Update package.json with the version number
+        run: |
+          | VERSION='${{ inputs.version_number }}' jq '.version=$ENV.VERSION' ./package.json > ./package.json
+
+      - name: Commit the changes
+        run: |
+          git add package.json && git commit -m "Release version v${{ inputs.version_number }}"
+
+      - name: Tag the commit
+        run: |
+          git tag v${{ inputs.version_number }}
+
+      - name: Push the tag
+        run: |
+          git push origin v${{ inputs.version_number }}
+
+      - name: Create the release
+        run: |
+          gh release create v${{ inputs.version_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push the npm package
+        run: |
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
This introduces a Github Actions workflow that can be triggered manually whenever we want to release a new CDS version. The release process will be as follows:
- Start a new run of this workflow (Github limitations mean this is only possible after this is merged because it is a manually triggered workflow)
- Before starting the release workflow, you have to fill in the number of the new version to release, and the hash of the commit that should be tagged with this new version.
- Start the workflow
- The workflow will then:
  - Check out the commit that you specified
  - Update `package.json` with the desired version number
  - Commit this change
  - Tag this commit with the version number, prefixed with a `v`.
  - Push the tag to the Github repo
  - Create a Github release for the newly added tag
  - Publish the new version on npmjs.org so projects can install it

Once this is merged, the workflow can be run (not before, due to Github limitations). We can then go over the functionality, if desired.