### PR TITLE
Fix a syntax error in the workflow to release new versions

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Update package.json with the version number
         run: |
-          | VERSION='${{ inputs.version_number }}' jq '.version=$ENV.VERSION' ./package.json > ./package.json
+          VERSION='${{ inputs.version_number }}' jq '.version=$ENV.VERSION' ./package.json > ./package.json
 
       - name: Commit the changes
         run: |


### PR DESCRIPTION
This fixes `line 1: syntax error near unexpected token `|'` as seen at https://github.com/nihruk/cds/actions/runs/3250231172/jobs/5333627739