### PR TITLE
Replace set-output in Github Actions with environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,14 +33,13 @@ jobs:
           node-version: ${{ matrix.nodejs }}
 
       - name: Get the npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "npm_cache_dir=$(npm config get cache)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Cache npm
         uses: actions/cache@v3
         with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          path: ${{ env.npm_cache_dir }}
           key: npm-${{ hashFiles('./package.json') }}
           restore-keys: |
             npm-


### PR DESCRIPTION
This fixes the warnings (and as of June 2023 actual test failures) as seen during our test runs, such as at https://github.com/nihruk/cds/actions/runs/3362145958:
`The ``set-output`` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`

## How to verify the fix
No more warnings after running tests for this PR: https://github.com/nihruk/cds/actions/runs/3393768076